### PR TITLE
Add possibility to read file as binary string, array buffer or data URL

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -6,6 +6,7 @@ import { useFilePicker } from '../src';
 const App = () => {
   const [filesContent, errors, openFileSelector, loading] = useFilePicker({
     multiple: true,
+    readAs: 'Text', // availible formats: "Text" | "BinaryString" | "ArrayBuffer" | "DataURL"
     // accept: '.ics,.pdf',
     accept: ['.json', '.pdf'],
   });
@@ -31,6 +32,11 @@ const App = () => {
       <br />
       Number of selected files:
       {filesContent.length}
+      <br />
+      {filesContent.map(content => (
+        <div style={{ lineBreak: 'anywhere' }}>{JSON.stringify(content.content)}</div>
+      ))}
+      {!!filesContent.length && <img src={filesContent[0].content} />}
     </div>
   );
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-export type ReadType = "Text" | "BinaryString" | "ArrayBuffer" | "DataURL";
+export type ReadType = 'Text' | 'BinaryString' | 'ArrayBuffer' | 'DataURL';
 
 export type ReaderMethod = keyof FileReader;
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,11 @@
+export type ReadType = "Text" | "BinaryString" | "ArrayBuffer" | "DataURL";
+
+export type ReaderMethod = keyof FileReader;
+
 export interface UseFilePickerConfig extends Options {
   multiple?: boolean;
   accept?: string | string[];
+  readAs?: ReadType;
 }
 
 export interface FileContent {

--- a/src/useFilePicker.tsx
+++ b/src/useFilePicker.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { fromEvent, FileWithPath } from 'file-selector';
-import { UseFilePickerConfig, FileContent, FilePickerReturnTypes, FileError } from './interfaces';
+import { UseFilePickerConfig, FileContent, FilePickerReturnTypes, FileError, ReaderMethod } from './interfaces';
 
-function useFilePicker({ accept = '*', multiple = true, minFileSize, maxFileSize }: UseFilePickerConfig): FilePickerReturnTypes {
+function useFilePicker({ accept = '*', multiple = true, readAs = 'Text', minFileSize, maxFileSize }: UseFilePickerConfig): FilePickerReturnTypes {
   const [files, setFiles] = useState<FileWithPath[]>([]);
   const [filesContent, setFilesContent] = useState<FileContent[]>([]);
   const [fileErrors, setFileErrors] = useState<FileError[]>([]);
@@ -27,7 +27,10 @@ function useFilePicker({ accept = '*', multiple = true, minFileSize, maxFileSize
       (file: FileWithPath) =>
         new Promise((resolve: (fileContent: FileContent) => void, reject: (reason: FileError) => void) => {
           const reader = new FileReader();
-          reader.readAsText(file);
+
+          //availible reader methods: readAsText, readAsBinaryString, readAsArrayBuffer, readAsDataURL
+          const readStrategy = reader[`readAs${readAs}` as ReaderMethod] as typeof reader.readAsText;
+          readStrategy.call(reader, file);
 
           reader.onload = () => {
             if (minFileSize) {


### PR DESCRIPTION
With different file formats, comes a need for different storage types. Before this change, the reader was transforming the uploaded file to a string. So it was not possible to upload a photo for example, because it cannot be stored as plain text.

When "readAs" prop is set to "DataURL", You can safely upload a photo and then display it on the page or even upload it to the external server with the help of Blob.
