### PR TITLE
Fix main es module filename 

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,14 +54,14 @@
     "react-file-selector"
   ],
   "author": "Milosz Jankiewicz",
-  "module": "dist/usefilepicker.esm.js",
+  "module": "dist/use-file-picker.esm.js",
   "size-limit": [
     {
-      "path": "dist/usefilepicker.cjs.production.min.js",
+      "path": "dist/use-file-picker.cjs.production.min.js",
       "limit": "10 KB"
     },
     {
-      "path": "dist/usefilepicker.esm.js",
+      "path": "dist/use-file-picker.esm.js",
       "limit": "10 KB"
     }
   ],


### PR DESCRIPTION
Fix for #13 ESM Dist files have different name than package.json 
Tested with Vite bundler.
Standard import:
```
import { useFilePicker } from 'use-file-picker';
```
works perfectly now.

