### PR TITLE
Fix crashing on dev environment because of unhandled rejections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/useFilePicker.tsx
+++ b/src/useFilePicker.tsx
@@ -51,15 +51,17 @@ function useFilePicker({
           .catch(err => Promise.reject(setFileErrors(f => [{ ...err, ...f }])))
       );
 
-      Promise.all(validations).then(() => {
-        if (!readFilesContent) {
-          setPlainFiles(plainFileObjectsRef.current);
-          return;
-        }
-        fromEvent(evt).then(files => {
-          setFiles(files as FileWithPath[]);
-        });
-      });
+      Promise.all(validations)
+        .then(() => {
+          if (!readFilesContent) {
+            setPlainFiles(plainFileObjectsRef.current);
+            return;
+          }
+          fromEvent(evt).then(files => {
+            setFiles(files as FileWithPath[]);
+          });
+        })
+        .catch(() => {});
     });
   };
 
@@ -109,13 +111,15 @@ function useFilePicker({
                 .catch(err => Promise.reject(addError(err)))
             );
 
-            Promise.all(validations).then(() =>
-              resolve({
-                content: reader.result as string,
-                name: file.name,
-                lastModified: file.lastModified,
-              } as FileContent)
-            );
+            Promise.all(validations)
+              .then(() =>
+                resolve({
+                  content: reader.result as string,
+                  name: file.name,
+                  lastModified: file.lastModified,
+                } as FileContent)
+              )
+              .catch(() => {});
           };
 
           reader.onerror = () => {


### PR DESCRIPTION
This pull request is aiming to resolve problems described in issue #27. 

Added no-operation handlers to rejected validator promises - before and after parsing. From now on, the browser won't log any errors whenever selected files do not pass validation. This should eliminate the problem of crashing dev environments.

I know that every particular validator produces its own promise, which is properly handled: 

 - line 51 for pre-parsing validation
```ts
validator
    .validateBeforeParsing(
       {
        accept,
        multiple,
        readAs,
        minFileSize,
        maxFileSize,
        imageSizeRestrictions,
        limitFilesConfig,
        readFilesContent,
       },
       plainFileObjectsRef.current
     ).catch(err => Promise.reject(setFileErrors(f => [{ ...err, ...f }])))
```
 - and line 109 for post-parsing validation
```ts
validator
    .validateAfterParsing(
       {
        accept,
        multiple,
        readAs,
        minFileSize,
        maxFileSize,
        imageSizeRestrictions,
        limitFilesConfig,
        readFilesContent,
       },
       file,
       reader
    ).catch(err => Promise.reject(addError(err)))
```

But this is needed as it gives us that granularity with error handling - we can show all errors that happened instead of generic "File did not pass validation" if we had used global handling. So I think this is a fair trade off between brevity and functionality. 