### PR TITLE
Add webkitdirectory option to pick directory

### DIFF
--- a/src/helpers/openFileDialog.ts
+++ b/src/helpers/openFileDialog.ts
@@ -1,4 +1,4 @@
-export function openFileDialog(accept: string, multiple: boolean, callback: (arg: Event) => void) {
+export function openFileDialog(accept: string, multiple: boolean, webkitdirectory: boolean, callback: (arg: Event) => void) {
   // this function must be called from a user
   // activation event (ie an onclick event)
 
@@ -11,6 +11,8 @@ export function openFileDialog(accept: string, multiple: boolean, callback: (arg
   inputElement.accept = accept;
   // Accept multiple files
   inputElement.multiple = multiple;
+  // Accept directory
+  inputElement.webkitdirectory = webkitdirectory;
   // set onchange event to call callback when user has selected file
   inputElement.addEventListener('change', callback);
   // set onblur event to call callback when user has selected file on Safari

--- a/src/helpers/openFileDialog.ts
+++ b/src/helpers/openFileDialog.ts
@@ -12,6 +12,7 @@ export function openFileDialog(accept: string, multiple: boolean, webkitdirector
   // Accept multiple files
   inputElement.multiple = multiple;
   // Accept directory
+  /* @ts-expect-error */
   inputElement.webkitdirectory = webkitdirectory;
   // set onchange event to call callback when user has selected file
   inputElement.addEventListener('change', callback);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,6 +11,7 @@ export interface LimitFilesConfig {
 
 export interface UseFilePickerConfig extends Options {
   multiple?: boolean;
+  webkitdirectory?: boolean;
   accept?: string | string[];
   readAs?: ReadType;
   limitFilesConfig?: LimitFilesConfig;

--- a/src/useFilePicker.tsx
+++ b/src/useFilePicker.tsx
@@ -10,6 +10,7 @@ import ImageDimensionsValidator from './validators/imageDimensionsValidator';
 const VALIDATORS: Validator[] = [new FileSizeValidator(), new FilesLimitValidator(), new ImageDimensionsValidator()];
 
 function useFilePicker({
+  webkitdirectory = false,
   accept = '*',
   multiple = true,
   readAs = 'Text',
@@ -29,7 +30,7 @@ function useFilePicker({
 
   const openFileSelector = () => {
     const fileExtensions = accept instanceof Array ? accept.join(',') : accept;
-    openFileDialog(fileExtensions, multiple, evt => {
+    openFileDialog(fileExtensions, multiple, webkitdirectory, evt => {
       clear();
       const inputElement = evt.target as HTMLInputElement;
       plainFileObjectsRef.current = inputElement.files ? Array.from(inputElement.files) : [];


### PR DESCRIPTION
The '/* @ts-expect-error */' is used to pass compilation. I don't know if upgrading the dependencies version will get rid of it.