### PR TITLE
Append input on body (required on iOS safari)

### DIFF
--- a/src/helpers/openFileDialog.ts
+++ b/src/helpers/openFileDialog.ts
@@ -21,12 +21,6 @@ export function openFileDialog(accept: string, multiple: boolean, callback: (arg
     // remove element
     document.body.removeChild(inputElement);
   });
-  // set onblur event to call callback when user has selected file on Safari
-  inputElement.addEventListener('blur', arg => {
-    callback(arg);
-    // remove element
-    document.body.removeChild(inputElement);
-  });
   // dispatch a click event to open the file dialog
   inputElement.dispatchEvent(new MouseEvent('click'));
 }

--- a/src/helpers/openFileDialog.ts
+++ b/src/helpers/openFileDialog.ts
@@ -4,6 +4,9 @@ export function openFileDialog(accept: string, multiple: boolean, callback: (arg
 
   // Create an input element
   var inputElement = document.createElement('input');
+  // Hide element and append to body (required to run on iOS safari)
+  inputElement.style.display = 'none';
+  document.body.appendChild(inputElement);
   // Set its type to file
   inputElement.type = 'file';
   // Set accept to the file types you want the user to select.
@@ -12,9 +15,18 @@ export function openFileDialog(accept: string, multiple: boolean, callback: (arg
   // Accept multiple files
   inputElement.multiple = multiple;
   // set onchange event to call callback when user has selected file
-  inputElement.addEventListener('change', callback);
+  //inputElement.addEventListener('change', callback);
+  inputElement.addEventListener('change', arg => {
+    callback(arg);
+    // remove element
+    document.body.removeChild(inputElement);
+  });
   // set onblur event to call callback when user has selected file on Safari
-  inputElement.addEventListener('blur', callback);
+  inputElement.addEventListener('blur', arg => {
+    callback(arg);
+    // remove element
+    document.body.removeChild(inputElement);
+  });
   // dispatch a click event to open the file dialog
   inputElement.dispatchEvent(new MouseEvent('click'));
 }


### PR DESCRIPTION
This pull request fixes an iOS safari problem: you need to append the input element to the body to trigger the events and callback after selecting the files.