### PR TITLE
`clear` callback is cached with useCallback

### DIFF
--- a/src/useFilePicker.tsx
+++ b/src/useFilePicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { fromEvent, FileWithPath } from 'file-selector';
 import { UseFilePickerConfig, FileContent, FilePickerReturnTypes, FileError, ReaderMethod } from './interfaces';
 import FileSizeValidator from './validators/fileSizeValidator';
@@ -65,12 +65,12 @@ function useFilePicker({
     });
   };
 
-  const clear = (): void => {
+  const clear: () => void = useCallback(() => {
     setPlainFiles([]);
     setFiles([]);
     setFilesContent([]);
     setFileErrors([]);
-  };
+  }, []);
 
   useEffect(() => {
     if (files.length === 0) {


### PR DESCRIPTION
I faced an annoying issue when using this great hook: it returns a new `clear` function on each component render.

In my app I use it inside `useEffect` hook, so it seems reasonable to add `clear` to `useEffect` dependencies array.  But doing so resulted in that effect running much more frequently than I'd expect it to. So I checked the source code and here's the solution.