### PR TITLE
Export Typescript interfaces 

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,3 @@
 export { default as useFilePicker } from './useFilePicker';
 export { Validator } from './validators/validatorInterface';
+export * from './interfaces'

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -46,16 +46,16 @@ export interface FileError extends FileSizeError, FileReaderError, FileLimitErro
   name?: string;
 }
 
-interface FileReaderError {
+export interface FileReaderError {
   readerError?: DOMException | null;
 }
 
-interface FileLimitError {
+export interface FileLimitError {
   minLimitNotReached?: boolean;
   maxLimitExceeded?: boolean;
 }
 
-interface FileSizeError {
+export interface FileSizeError {
   fileSizeToolarge?: boolean;
   fileSizeTooSmall?: boolean;
 }


### PR DESCRIPTION
I ran into an issue using this library where I needed to use one of the interfaces in my application code  but they are not exported as part of the main library. I had to hack around it by importing the interface from `use-file-picker/dist/interfaces` directly. Hopefully this PR will be helpful for others who may run into this issue.