### PR TITLE
Enhancing use-file-picker to support file deletion and selection persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,11 @@
 
 ## Documentation
 
-#### Usage
-
 - [Simple txt reader](#simple-txt-file-content-reading)
 - [Image reader](#reading-and-rendering-images)
+- [On change callbacks](#on-change-callbacks)
 - [Advanced usage](#advanced-usage)
-
-#### API
-
+- [Imperative picker](#keeping-the-previously-selected-files-and-removing-them-from-selection)
 - [Props](#props)
 - [Returns](#returns)
 - [Interfaces](#interfaces)
@@ -28,13 +25,13 @@ or
 
 ## StoryBook
 
-https://use-file-picker.vercel.app/
+<https://use-file-picker.vercel.app/>
 
 ## Usage
 
-#### Simple txt file content reading
+### Simple txt file content reading
 
-https://codesandbox.io/s/inspiring-swartz-pjxze?file=/src/App.js
+<https://codesandbox.io/s/inspiring-swartz-pjxze?file=/src/App.js>
 
 ```jsx
 import { useFilePicker } from 'use-file-picker';
@@ -65,9 +62,9 @@ export default function App() {
 }
 ```
 
-#### Reading and rendering Images
+### Reading and rendering Images
 
-https://codesandbox.io/s/busy-nightingale-oox7z?file=/src/App.js
+<https://codesandbox.io/s/busy-nightingale-oox7z?file=/src/App.js>
 
 ```ts
 import { useFilePicker } from 'use-file-picker';
@@ -113,9 +110,58 @@ export default function App() {
 }
 ```
 
+### On change callbacks
+
+```ts
+import { useFilePicker } from 'use-file-picker';
+import React from 'react';
+
+export default function App() {
+  const [openFileSelector, { filesContent, loading, errors }] = useFilePicker({
+    readAs: 'DataURL',
+    accept: 'image/*',
+    multiple: true,
+    onFilesSelected: ({ plainFiles, filesContent, errors }) => {
+      // this callback is always called, even if there are errors
+      console.log('onFilesSelected', plainFiles, filesContent, errors);
+    },
+    onFilesRejected: ({ errors }) => {
+      // this callback is called when there were validation errors
+      console.log('onFilesRejected', errors);
+    },
+    onFilesSuccessfulySelected: ({ plainFiles, filesContent }) => {
+      // this callback is called when there were no validation errors
+      console.log('onFilesSuccessfulySelected', plainFiles, filesContent);
+    },
+  });
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (errors.length) {
+    return <div>Error...</div>;
+  }
+
+  return (
+    <div>
+      <button onClick={() => openFileSelector()}>Select files </button>
+      <br />
+      {filesContent.map((file, index) => (
+        <div key={index}>
+          <h2>{file.name}</h2>
+          <img alt={file.name} src={file.content}></img>
+          <br />
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
 ### Advanced usage
 
-https://codesandbox.io/s/musing-moon-wuq4u?file=/src/App.js
+<https://codesandbox.io/s/musing-moon-wuq4u?file=/src/App.js>
 
 ```ts
 import { useFilePicker } from 'use-file-picker';
@@ -169,6 +215,86 @@ export default function App() {
 }
 ```
 
+### Keeping the previously selected files and removing them from selection on demand
+
+If you want to keep the previously selected files and remove them from the selection, you can use a separate hook called `useImperativeFilePicker` that is also exported in this package. For files removal, you can use `removeFileByIndex` or `removeFileByReference` functions.
+
+```ts
+import React from 'react';
+import { useImperativeFilePicker } from 'use-file-picker';
+
+const Imperative = () => {
+  const [
+    openFileSelector,
+    { filesContent, loading, errors, plainFiles, clear, removeFileByIndex, removeFileByReference },
+  ] = useImperativeFilePicker({
+    multiple: true,
+    readAs: 'Text',
+    readFilesContent: true,
+    onFilesSelected: ({ plainFiles, filesContent, errors }) => {
+      // this callback is always called, even if there are errors
+      console.log('onFilesSelected', plainFiles, filesContent, errors);
+    },
+    onFilesRejected: ({ errors }) => {
+      // this callback is called when there were validation errors
+      console.log('onFilesRejected', errors);
+    },
+    onFilesSuccessfulySelected: ({ plainFiles, filesContent }) => {
+      // this callback is called when there were no validation errors
+      console.log('onFilesSuccessfulySelected', plainFiles, filesContent);
+    },
+  });
+
+  if (errors.length) {
+    return (
+      <div>
+        <button onClick={() => openFileSelector()}>Something went wrong, retry! </button>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          {console.log(errors)}
+          {Object.entries(errors[0])
+            .filter(([key, value]) => key !== 'name' && value)
+            .map(([key]) => (
+              <div key={key}>{key}</div>
+            ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <button onClick={async () => openFileSelector()}>Select file</button>
+      <button onClick={() => clear()}>Clear</button>
+      <br />
+      Amount of selected files:
+      {plainFiles.length}
+      <br />
+      Amount of filesContent:
+      {filesContent.length}
+      <br />
+      {plainFiles.map((file, i) => (
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center' }} key={file.name}>
+            <div>{file.name}</div>
+            <button style={{ marginLeft: 24 }} onClick={() => removeFileByReference(file)}>
+              Remove by reference
+            </button>
+            <button style={{ marginLeft: 24 }} onClick={() => removeFileByIndex(i)}>
+              Remove by index
+            </button>
+          </div>
+          <div>{filesContent[i]?.content}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+```
+
 ## API
 
 ### Props
@@ -183,7 +309,7 @@ export default function App() {
 | minFileSize                    | Set minimum limit of file size in megabytes                                                                                                                                                                                    | n/a           | 0.01 - 50                                         |
 | maxFileSize                    | Set maximum limit of file size in megabytes                                                                                                                                                                                    | n/a           | 0.01 - 50                                         |
 | imageSizeRestrictions          | Set maximum and minimum constraints for image size in pixels                                                                                                                                                                   | n/a           | { maxHeight: 1024, minWidth: 768, minHeight:480 } |
-| validators                     | Add custom [validation](#Custom-validation) logic                                                                                                                                                                              | []            | [MyValidator, MySecondValidator]                  |
+| validators                     | Add custom [validation](#custom-validation) logic                                                                                                                                                                              | []            | [MyValidator, MySecondValidator]                  |
 | initializeWithCustomParameters | allows for customization of the input element that is created by the file picker. It accepts a function that takes in the input element as a parameter and can be used to set any desired attributes or styles on the element. | n/a           | (input) => input.setAttribute("disabled", "")     |
 | onFilesSelected                | A callback function that is called when files are successfully selected. The function is passed an array of objects with information about each successfully selected file                                                     | n/a           | (data) => console.log(data)                       |
 | onFilesSuccessfulySelected     | A callback function that is called when files are successfully selected. The function is passed an array of objects with information about each successfully selected file                                                     | n/a           | (data) => console.log(data)                       |
@@ -241,8 +367,8 @@ const customValidator: Validator = {
 
 ```ts
 LimitFilesConfig {
-	min?: number;
-	max?: number;
+  min?: number;
+  max?: number;
 }
 ```
 
@@ -250,7 +376,7 @@ LimitFilesConfig {
 
 ```ts
 UseFilePickerConfig extends Options {
-	multiple?: boolean;
+  multiple?: boolean;
   accept?: string | string[];
   readAs?: ReadType;
   limitFilesConfig?: LimitFilesConfig;
@@ -268,9 +394,9 @@ UseFilePickerConfig extends Options {
 
 ```ts
 FileContent {
-	lastModified: number;
-	name: string;
-	content: string;
+  lastModified: number;
+  name: string;
+  content: string;
 }
 ```
 
@@ -278,10 +404,10 @@ FileContent {
 
 ```ts
 ImageDims {
-	minWidth?: number;
-	maxWidth?: number;
-	minHeight?: number;
-	maxHeight?: number;
+  minWidth?: number;
+  maxWidth?: number;
+  minHeight?: number;
+  maxHeight?: number;
 }
 ```
 
@@ -289,8 +415,8 @@ ImageDims {
 
 ```ts
 Options extends ImageDims {
-	minFileSize?: number;
-	maxFileSize?: number;
+  minFileSize?: number;
+  maxFileSize?: number;
 }
 ```
 
@@ -298,7 +424,7 @@ Options extends ImageDims {
 
 ```ts
 FileError extends FileSizeError, FileReaderError, FileLimitError, ImageDimensionError {
-	name?: string;
+  name?: string;
 }
 ```
 
@@ -306,7 +432,7 @@ FileError extends FileSizeError, FileReaderError, FileLimitError, ImageDimension
 
 ```ts
 FileReaderError {
-	readerError?: DOMException | null;
+  readerError?: DOMException | null;
 }
 ```
 
@@ -314,8 +440,8 @@ FileReaderError {
 
 ```ts
 FileLimitError {
-	minLimitNotReached?: boolean;
-	maxLimitExceeded?: boolean;
+  minLimitNotReached?: boolean;
+  maxLimitExceeded?: boolean;
 }
 ```
 
@@ -323,8 +449,8 @@ FileLimitError {
 
 ```ts
 FileSizeError {
-	fileSizeToolarge?: boolean;
-	fileSizeTooSmall?: boolean;
+  fileSizeToolarge?: boolean;
+  fileSizeTooSmall?: boolean;
 }
 ```
 
@@ -332,11 +458,11 @@ FileSizeError {
 
 ```ts
 ImageDimensionError {
-	imageWidthTooBig?: boolean;
-	imageWidthTooSmall?: boolean;
-	imageHeightTooBig?: boolean;
-	imageHeightTooSmall?: boolean;
-	imageNotLoaded?: boolean;
+  imageWidthTooBig?: boolean;
+  imageWidthTooSmall?: boolean;
+  imageHeightTooBig?: boolean;
+  imageHeightTooSmall?: boolean;
+  imageNotLoaded?: boolean;
 }
 ```
 

--- a/example/imperative.tsx
+++ b/example/imperative.tsx
@@ -3,24 +3,26 @@ import * as React from 'react';
 import { useImperativeFilePicker } from '../src';
 
 const Imperative = () => {
-  const [openFileSelector, { filesContent, loading, errors, plainFiles, clear, removeFileByIndex }] =
-    useImperativeFilePicker({
-      multiple: true,
-      readAs: 'Text',
-      readFilesContent: true,
-      onFilesSelected: ({ plainFiles, filesContent, errors }) => {
-        // this callback is always called, even if there are errors
-        console.log('onFilesSelected', plainFiles, filesContent, errors);
-      },
-      onFilesRejected: ({ errors }) => {
-        // this callback is called when there were validation errors
-        console.log('onFilesRejected', errors);
-      },
-      onFilesSuccessfulySelected: ({ plainFiles, filesContent }) => {
-        // this callback is called when there were no validation errors
-        console.log('onFilesSuccessfulySelected', plainFiles, filesContent);
-      },
-    });
+  const [
+    openFileSelector,
+    { filesContent, loading, errors, plainFiles, clear, removeFileByIndex, removeFileByReference },
+  ] = useImperativeFilePicker({
+    multiple: true,
+    readAs: 'Text',
+    readFilesContent: true,
+    onFilesSelected: ({ plainFiles, filesContent, errors }) => {
+      // this callback is always called, even if there are errors
+      console.log('onFilesSelected', plainFiles, filesContent, errors);
+    },
+    onFilesRejected: ({ errors }) => {
+      // this callback is called when there were validation errors
+      console.log('onFilesRejected', errors);
+    },
+    onFilesSuccessfulySelected: ({ plainFiles, filesContent }) => {
+      // this callback is called when there were no validation errors
+      console.log('onFilesSuccessfulySelected', plainFiles, filesContent);
+    },
+  });
 
   if (errors.length) {
     return (
@@ -47,18 +49,24 @@ const Imperative = () => {
       <button onClick={async () => openFileSelector()}>Select file</button>
       <button onClick={() => clear()}>Clear</button>
       <br />
-      Number of selected files:
+      Amount of selected files:
       {plainFiles.length}
       <br />
-      {/* If readAs is set to DataURL, You can display an image */}
-      {!!filesContent.length && <div>{filesContent[0].content}</div>}
+      Amount of filesContent:
+      {filesContent.length}
       <br />
       {plainFiles.map((file, i) => (
-        <div style={{ display: 'flex', alignItems: 'center' }} key={file.name}>
-          <div>{file.name}</div>
-          <button style={{ marginLeft: 24 }} onClick={() => removeFileByIndex(i)}>
-            X
-          </button>
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center' }} key={file.name}>
+            <div>{file.name}</div>
+            <button style={{ marginLeft: 24 }} onClick={() => removeFileByReference(file)}>
+              Remove by reference
+            </button>
+            <button style={{ marginLeft: 24 }} onClick={() => removeFileByIndex(i)}>
+              Remove by index
+            </button>
+          </div>
+          <div>{filesContent[i]?.content}</div>
         </div>
       ))}
     </div>

--- a/example/imperative.tsx
+++ b/example/imperative.tsx
@@ -1,0 +1,68 @@
+import 'react-app-polyfill/ie11';
+import * as React from 'react';
+import { useImperativeFilePicker } from '../src';
+
+const Imperative = () => {
+  const [openFileSelector, { filesContent, loading, errors, plainFiles, clear, removeFileByIndex }] =
+    useImperativeFilePicker({
+      multiple: true,
+      readAs: 'Text',
+      readFilesContent: true,
+      onFilesSelected: ({ plainFiles, filesContent, errors }) => {
+        // this callback is always called, even if there are errors
+        console.log('onFilesSelected', plainFiles, filesContent, errors);
+      },
+      onFilesRejected: ({ errors }) => {
+        // this callback is called when there were validation errors
+        console.log('onFilesRejected', errors);
+      },
+      onFilesSuccessfulySelected: ({ plainFiles, filesContent }) => {
+        // this callback is called when there were no validation errors
+        console.log('onFilesSuccessfulySelected', plainFiles, filesContent);
+      },
+    });
+
+  if (errors.length) {
+    return (
+      <div>
+        <button onClick={() => openFileSelector()}>Something went wrong, retry! </button>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          {console.log(errors)}
+          {Object.entries(errors[0])
+            .filter(([key, value]) => key !== 'name' && value)
+            .map(([key]) => (
+              <div key={key}>{key}</div>
+            ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <button onClick={async () => openFileSelector()}>Select file</button>
+      <button onClick={() => clear()}>Clear</button>
+      <br />
+      Number of selected files:
+      {plainFiles.length}
+      <br />
+      {/* If readAs is set to DataURL, You can display an image */}
+      {!!filesContent.length && <div>{filesContent[0].content}</div>}
+      <br />
+      {plainFiles.map((file, i) => (
+        <div style={{ display: 'flex', alignItems: 'center' }} key={file.name}>
+          <div>{file.name}</div>
+          <button style={{ marginLeft: 24 }} onClick={() => removeFileByIndex(i)}>
+            X
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Imperative;

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -85,7 +85,7 @@ const App = () => {
       <button onClick={async () => openFileSelector()}>Select file</button>
       <button onClick={() => clear()}>Clear</button>
       <br />
-      Number of selected files:
+      Amount of selected files:
       {plainFiles.length}
       <br />
       {/* If readAs is set to DataURL, You can display an image */}

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { useFilePicker } from '../src';
 import type { Validator } from '../src';
+import Imperative from './imperative';
 
 const customValidator: Validator = {
   /**
@@ -97,4 +98,12 @@ const App = () => {
   );
 };
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+  <>
+    <h2>useFilePicker</h2>
+    <App />
+    <h2>useImperativeFilePicker</h2>
+    <Imperative />
+  </>,
+  document.getElementById('root')
+);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
 export { default as useFilePicker } from './useFilePicker';
+export { default as useImperativeFilePicker } from './useImperativeFilePicker';
 export type { Validator } from './validators/validatorInterface';
 export * from './interfaces';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -46,6 +46,11 @@ export type FilePickerReturnTypes = [
   { filesContent: FileContent[]; errors: FileError[]; loading: boolean; plainFiles: File[]; clear: () => void }
 ];
 
+export type ImperativeFilePickerReturnTypes = [
+  FilePickerReturnTypes[0],
+  FilePickerReturnTypes[1] & { removeFileByIndex: (index: number) => void }
+];
+
 export interface ImageDims {
   minWidth?: number;
   maxWidth?: number;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,7 +11,7 @@ export interface LimitFilesConfig {
 }
 
 export type SelectedFiles = {
-  plainFiles: FileWithPath[];
+  plainFiles: File[];
   filesContent: FileContent[];
 };
 
@@ -48,7 +48,7 @@ export type FilePickerReturnTypes = [
 
 export type ImperativeFilePickerReturnTypes = [
   FilePickerReturnTypes[0],
-  FilePickerReturnTypes[1] & { removeFileByIndex: (index: number) => void }
+  FilePickerReturnTypes[1] & { removeFileByIndex: (index: number) => void; removeFileByReference: (file: File) => void }
 ];
 
 export interface ImageDims {

--- a/src/useImperativeFilePicker.tsx
+++ b/src/useImperativeFilePicker.tsx
@@ -1,52 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { FileContent, ImperativeFilePickerReturnTypes, UseFilePickerConfig } from './interfaces';
 import useFilePicker from './useFilePicker';
-import { Validator } from './validators/validatorInterface';
-
-/**
- * File limit validator has to be overriden to take into account the files that were previously selected
- * @param previousPlainFiles files that were previously selected
- * @returns a validator that checks if the amount of files selected previously and in the current batch is within the limits
- */
-const persistentFileLimitValidator: (previousPlainFiles: File[]) => Validator = previousPlainFiles => ({
-  validateBeforeParsing(config: UseFilePickerConfig, plainFiles: File[]): Promise<void> {
-    const { limitFilesConfig } = config;
-    const fileAmount = previousPlainFiles.length + plainFiles.length;
-    if (limitFilesConfig) {
-      if (limitFilesConfig.max && fileAmount > limitFilesConfig.max) {
-        return Promise.reject({ maxLimitExceeded: true });
-      }
-
-      if (limitFilesConfig.min && fileAmount < limitFilesConfig.min) {
-        return Promise.reject({ minLimitNotReached: true });
-      }
-    }
-    return Promise.resolve();
-  },
-  validateAfterParsing(): Promise<void> {
-    return Promise.resolve();
-  },
-});
-
-// Comparators needed to check if the file was already selected previously
-
-const areFilesEqual = (file1: File | undefined, file2: File | undefined) =>
-  !!file1 &&
-  !!file2 &&
-  file1.name === file2.name &&
-  file1.lastModified === file2.lastModified &&
-  file1.webkitRelativePath === file2.webkitRelativePath &&
-  file1.size === file2.size &&
-  file1.type === file2.type;
-
-const areFilesContentEqual = (file1: FileContent | undefined, file2: FileContent | undefined) =>
-  !!file1 &&
-  !!file2 &&
-  file1.name === file2.name &&
-  file1.lastModified === file2.lastModified &&
-  file1.size === file2.size &&
-  file1.type === file2.type &&
-  file1.content === file2.content;
+import persistentFileLimitValidator from './validators/persistentFilesLimitValidator';
 
 /**
  * A version of useFilePicker hook that keeps selected files between selections. On top of that it allows to remove files from the selection.
@@ -57,7 +12,7 @@ function useImperativeFilePicker(props: UseFilePickerConfig): ImperativeFilePick
   const [allPlainFiles, setAllPlainFiles] = useState<File[]>([]);
   const [allFilesContent, setAllFilesContent] = useState<FileContent[]>([]);
 
-  const [open, { plainFiles, filesContent, loading, errors, clear }] = useFilePicker({
+  const [open, { loading, errors, clear }] = useFilePicker({
     ...props,
     validators: [persistentFileLimitValidator(allPlainFiles), ...(props.validators || [])],
     onFilesSelected: data => {
@@ -73,6 +28,9 @@ function useImperativeFilePicker(props: UseFilePickerConfig): ImperativeFilePick
       });
     },
     onFilesSuccessfulySelected: data => {
+      setAllPlainFiles(previousPlainFiles => previousPlainFiles.concat(data.plainFiles));
+      setAllFilesContent(previousFilesContent => previousFilesContent.concat(data.filesContent));
+
       if (!onFilesSuccessfulySelected) return;
       // override the files property to return all files that were selected previously and in the current batch
       onFilesSuccessfulySelected({
@@ -82,53 +40,49 @@ function useImperativeFilePicker(props: UseFilePickerConfig): ImperativeFilePick
     },
   });
 
-  const clearPreviousFiles = () => {
+  const clearPreviousFiles = useCallback(() => {
     setAllPlainFiles([]);
     if (readFilesContent) {
       setAllFilesContent([]);
     }
-  };
+  }, [readFilesContent]);
 
-  const clearAll = () => {
+  const clearAll = useCallback(() => {
     clear();
     clearPreviousFiles();
-  };
+  }, [clear, clearPreviousFiles]);
 
-  const removeFileByIndex = (index: number) => {
-    setAllPlainFiles([...allPlainFiles.slice(0, index), ...allPlainFiles.slice(index + 1)]);
+  const removeFileByIndex = useCallback((index: number) => {
+    setAllPlainFiles(previousPlainFiles => [
+      ...previousPlainFiles.slice(0, index),
+      ...previousPlainFiles.slice(index + 1),
+    ]);
+    setAllFilesContent(previousFilesContent => [
+      ...previousFilesContent.slice(0, index),
+      ...previousFilesContent.slice(index + 1),
+    ]);
+  }, []);
 
-    if (!readFilesContent) return;
-    setAllFilesContent([...allFilesContent.slice(0, index), ...allFilesContent.slice(index + 1)]);
-  };
-
-  useEffect(() => {
-    if (errors.length > 0) {
-      clearPreviousFiles();
-      return;
-    }
-    // If the last file in the previous batch is the same as the last file in the current batch, we don't need to update the state
-    if (areFilesEqual(allPlainFiles.at(-1), plainFiles.at(-1))) return;
-
-    setAllPlainFiles(previousPlainFiles => previousPlainFiles.concat(plainFiles));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [plainFiles, errors]);
-
-  useEffect(() => {
-    if (errors.length > 0) {
-      clearPreviousFiles();
-      return;
-    }
-    if (!readFilesContent) return;
-    // If the last file in the previous batch is the same as the last file in the current batch, we don't need to update the state
-    if (areFilesContentEqual(allFilesContent.at(-1), filesContent.at(-1))) return;
-
-    setAllFilesContent(previousFilesContent => previousFilesContent.concat(filesContent));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filesContent, readFilesContent]);
+  const removeFileByReference = useCallback(
+    (file: File) => {
+      const index = allPlainFiles.findIndex(f => f === file);
+      if (index === -1) return;
+      removeFileByIndex(index);
+    },
+    [removeFileByIndex, allPlainFiles]
+  );
 
   return [
     open,
-    { plainFiles: allPlainFiles, filesContent: allFilesContent, loading, errors, clear: clearAll, removeFileByIndex },
+    {
+      plainFiles: allPlainFiles,
+      filesContent: allFilesContent,
+      loading,
+      errors,
+      clear: clearAll,
+      removeFileByIndex,
+      removeFileByReference,
+    },
   ];
 }
 

--- a/src/useImperativeFilePicker.tsx
+++ b/src/useImperativeFilePicker.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react';
+import { FileContent, ImperativeFilePickerReturnTypes, UseFilePickerConfig } from './interfaces';
+import useFilePicker from './useFilePicker';
+import { Validator } from './validators/validatorInterface';
+
+/**
+ * File limit validator has to be overriden to take into account the files that were previously selected
+ * @param previousPlainFiles files that were previously selected
+ * @returns a validator that checks if the amount of files selected previously and in the current batch is within the limits
+ */
+const persistentFileLimitValidator: (previousPlainFiles: File[]) => Validator = previousPlainFiles => ({
+  validateBeforeParsing(config: UseFilePickerConfig, plainFiles: File[]): Promise<void> {
+    const { limitFilesConfig } = config;
+    const fileAmount = previousPlainFiles.length + plainFiles.length;
+    if (limitFilesConfig) {
+      if (limitFilesConfig.max && fileAmount > limitFilesConfig.max) {
+        return Promise.reject({ maxLimitExceeded: true });
+      }
+
+      if (limitFilesConfig.min && fileAmount < limitFilesConfig.min) {
+        return Promise.reject({ minLimitNotReached: true });
+      }
+    }
+    return Promise.resolve();
+  },
+  validateAfterParsing(): Promise<void> {
+    return Promise.resolve();
+  },
+});
+
+// Comparators needed to check if the file was already selected previously
+
+const areFilesEqual = (file1: File | undefined, file2: File | undefined) =>
+  !!file1 &&
+  !!file2 &&
+  file1.name === file2.name &&
+  file1.lastModified === file2.lastModified &&
+  file1.webkitRelativePath === file2.webkitRelativePath &&
+  file1.size === file2.size &&
+  file1.type === file2.type;
+
+const areFilesContentEqual = (file1: FileContent | undefined, file2: FileContent | undefined) =>
+  !!file1 &&
+  !!file2 &&
+  file1.name === file2.name &&
+  file1.lastModified === file2.lastModified &&
+  file1.size === file2.size &&
+  file1.type === file2.type &&
+  file1.content === file2.content;
+
+/**
+ * A version of useFilePicker hook that keeps selected files between selections. On top of that it allows to remove files from the selection.
+ */
+function useImperativeFilePicker(props: UseFilePickerConfig): ImperativeFilePickerReturnTypes {
+  const { readFilesContent, onFilesSelected, onFilesSuccessfulySelected } = props;
+
+  const [allPlainFiles, setAllPlainFiles] = useState<File[]>([]);
+  const [allFilesContent, setAllFilesContent] = useState<FileContent[]>([]);
+
+  const [open, { plainFiles, filesContent, loading, errors, clear }] = useFilePicker({
+    ...props,
+    validators: [persistentFileLimitValidator(allPlainFiles), ...(props.validators || [])],
+    onFilesSelected: data => {
+      if (!onFilesSelected) return;
+      if (data.errors?.length) {
+        return onFilesSelected(data);
+      }
+      // override the files property to return all files that were selected previously and in the current batch
+      onFilesSelected({
+        errors: undefined,
+        plainFiles: [...allPlainFiles, ...(data.plainFiles || [])],
+        filesContent: [...allFilesContent, ...(data.filesContent || [])],
+      });
+    },
+    onFilesSuccessfulySelected: data => {
+      if (!onFilesSuccessfulySelected) return;
+      // override the files property to return all files that were selected previously and in the current batch
+      onFilesSuccessfulySelected({
+        plainFiles: [...allPlainFiles, ...(data.plainFiles || [])],
+        filesContent: [...allFilesContent, ...(data.filesContent || [])],
+      });
+    },
+  });
+
+  const clearPreviousFiles = () => {
+    setAllPlainFiles([]);
+    if (readFilesContent) {
+      setAllFilesContent([]);
+    }
+  };
+
+  const clearAll = () => {
+    clear();
+    clearPreviousFiles();
+  };
+
+  const removeFileByIndex = (index: number) => {
+    setAllPlainFiles([...allPlainFiles.slice(0, index), ...allPlainFiles.slice(index + 1)]);
+
+    if (!readFilesContent) return;
+    setAllFilesContent([...allFilesContent.slice(0, index), ...allFilesContent.slice(index + 1)]);
+  };
+
+  useEffect(() => {
+    if (errors.length > 0) {
+      clearPreviousFiles();
+      return;
+    }
+    // If the last file in the previous batch is the same as the last file in the current batch, we don't need to update the state
+    if (areFilesEqual(allPlainFiles.at(-1), plainFiles.at(-1))) return;
+
+    setAllPlainFiles(previousPlainFiles => previousPlainFiles.concat(plainFiles));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [plainFiles, errors]);
+
+  useEffect(() => {
+    if (errors.length > 0) {
+      clearPreviousFiles();
+      return;
+    }
+    if (!readFilesContent) return;
+    // If the last file in the previous batch is the same as the last file in the current batch, we don't need to update the state
+    if (areFilesContentEqual(allFilesContent.at(-1), filesContent.at(-1))) return;
+
+    setAllFilesContent(previousFilesContent => previousFilesContent.concat(filesContent));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filesContent, readFilesContent]);
+
+  return [
+    open,
+    { plainFiles: allPlainFiles, filesContent: allFilesContent, loading, errors, clear: clearAll, removeFileByIndex },
+  ];
+}
+
+export default useImperativeFilePicker;

--- a/src/validators/persistentFilesLimitValidator/index.ts
+++ b/src/validators/persistentFilesLimitValidator/index.ts
@@ -1,0 +1,29 @@
+import { UseFilePickerConfig } from '../../interfaces';
+import { Validator } from '../validatorInterface';
+
+/**
+ * File limit validator has to be overriden to take into account the files that were previously selected
+ * @param previousPlainFiles files that were previously selected
+ * @returns a validator that checks if the amount of files selected previously and in the current batch is within the limits
+ */
+const persistentFileLimitValidator: (previousPlainFiles: File[]) => Validator = previousPlainFiles => ({
+  validateBeforeParsing(config: UseFilePickerConfig, plainFiles: File[]): Promise<void> {
+    const { limitFilesConfig } = config;
+    const fileAmount = previousPlainFiles.length + plainFiles.length;
+    if (limitFilesConfig) {
+      if (limitFilesConfig.max && fileAmount > limitFilesConfig.max) {
+        return Promise.reject({ maxLimitExceeded: true });
+      }
+
+      if (limitFilesConfig.min && fileAmount < limitFilesConfig.min) {
+        return Promise.reject({ minLimitNotReached: true });
+      }
+    }
+    return Promise.resolve();
+  },
+  validateAfterParsing(): Promise<void> {
+    return Promise.resolve();
+  },
+});
+
+export default persistentFileLimitValidator;

--- a/stories/ImperativeFilePicker.stories.tsx
+++ b/stories/ImperativeFilePicker.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
-import { useFilePicker, Validator } from '../src';
+import { useImperativeFilePicker, Validator } from '../src';
 import { FileContent, ReadType, UseFilePickerConfig } from '../src/interfaces';
 
 const renderDependingOnReaderType = (file: FileContent, readAs: ReadType) => {
@@ -30,8 +30,8 @@ const renderDependingOnReaderType = (file: FileContent, readAs: ReadType) => {
   }
 };
 
-const FilePickerComponent = (props: UseFilePickerConfig & { storyTitle: string }) => {
-  const [open, { filesContent, errors, plainFiles, loading }] = useFilePicker({ ...props });
+const ImperativeFilePickerComponent = (props: UseFilePickerConfig & { storyTitle: string }) => {
+  const [open, { filesContent, errors, plainFiles, loading }] = useImperativeFilePicker({ ...props });
 
   return (
     <>
@@ -72,7 +72,7 @@ const FilePickerComponent = (props: UseFilePickerConfig & { storyTitle: string }
 
 const meta: Meta = {
   title: 'use-file-picker',
-  component: FilePickerComponent,
+  component: ImperativeFilePickerComponent,
   argTypes: {
     multiple: {
       defaultValue: true,
@@ -131,12 +131,12 @@ const meta: Meta = {
 
 export default meta;
 
-const Template: Story<any> = args => <FilePickerComponent {...args} />;
+const Template: Story<any> = args => <ImperativeFilePickerComponent {...args} />;
 
 // By passing using the Args format for exported stories, you can control the props for a component for reuse in a test
 // https://storybook.js.org/docs/react/workflows/unit-testing
-export const DefaultPicker = Template.bind({});
-DefaultPicker.args = {
+export const ImperativePicker = Template.bind({});
+ImperativePicker.args = {
   storyTitle: 'Picker with default props',
   multiple: true,
   accept: '*',
@@ -144,13 +144,19 @@ DefaultPicker.args = {
   readFilesContent: true,
 };
 
-export const SingleFilePicker = Template.bind({}, { storyTitle: 'Allows to pick only one file', multiple: false });
-export const PickCertainFileType = Template.bind({}, { storyTitle: 'Selects only .txt files', accept: '.txt' });
-export const ReadContentAsImage = Template.bind(
+export const ImperativeSingleFilePicker = Template.bind(
+  {},
+  { storyTitle: 'Allows to pick only one file', multiple: false }
+);
+export const ImperativePickCertainFileType = Template.bind(
+  {},
+  { storyTitle: 'Selects only .txt files', accept: '.txt' }
+);
+export const ImperativeReadContentAsImage = Template.bind(
   {},
   { storyTitle: 'Reads selected files as DataURLs so they can be displayed by a browser', readAs: 'DataURL' }
 );
-export const LimitAmountOfFiles = Template.bind(
+export const ImperativeLimitAmountOfFiles = Template.bind(
   {},
   {
     storyTitle: 'Limit max and min amount of files. In this example picker allows to choose between 2 to 3 files.',
@@ -160,24 +166,24 @@ export const LimitAmountOfFiles = Template.bind(
     },
   }
 );
-export const DontReadFileContent = Template.bind(
+export const ImperativeDontReadFileContent = Template.bind(
   {},
   {
     storyTitle: 'Selected files are not read, plainFiles array contains File objects for selected files',
     readFilesContent: false,
   }
 );
-(DontReadFileContent as any).story = {
+(ImperativeDontReadFileContent as any).story = {
   name: "Don't Read File Content",
 };
-export const MaximumFileSize = Template.bind(
+export const ImperativeMaximumFileSize = Template.bind(
   {},
   {
     storyTitle: 'File size can be restricted. Picker allows only files that are smaller than 1 megabyte',
     maxFileSize: 1,
   }
 );
-export const ImageSizeRestrictions = Template.bind(
+export const ImperativeImageSizeRestrictions = Template.bind(
   {},
   {
     storyTitle:
@@ -200,7 +206,7 @@ const customValidator: Validator = {
         : rej({ fileRecentlyModified: true, lastModified: file.lastModified })
     ),
 };
-export const CustomValidators = Template.bind(
+export const ImperativeCustomValidators = Template.bind(
   {},
   {
     storyTitle:
@@ -208,14 +214,14 @@ export const CustomValidators = Template.bind(
     validators: [customValidator],
   }
 );
-export const customParameters = Template.bind(
+export const ImperativeCustomParameters = Template.bind(
   {},
   {
     storyTitle: 'Allows for adding custom parameters. In this example the button was initialized as disabled',
     initializeWithCustomParameters: (input: HTMLInputElement) => input.setAttribute('disabled', ''),
   }
 );
-export const onFilesSelected = Template.bind(
+export const ImperativeOnFilesSelected = Template.bind(
   {},
   {
     storyTitle:
@@ -225,7 +231,7 @@ export const onFilesSelected = Template.bind(
     },
   }
 );
-export const onFilesSuccessfulySelected = Template.bind(
+export const ImperativeOnFilesSuccessfulySelected = Template.bind(
   {},
   {
     storyTitle:
@@ -234,7 +240,7 @@ export const onFilesSuccessfulySelected = Template.bind(
   }
 );
 
-export const onFilesRejected = Template.bind(
+export const ImperativeOnFilesRejected = Template.bind(
   {},
   {
     storyTitle:

--- a/test/CustomValidators.test.tsx
+++ b/test/CustomValidators.test.tsx
@@ -1,163 +1,74 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
-import { useFilePicker, UseFilePickerConfig } from '../src/index';
-
-const isInputElement = (el: HTMLElement): el is HTMLInputElement => el instanceof HTMLInputElement;
-function createBigFile(sizeInBytes: number) {
-  const content = new ArrayBuffer(sizeInBytes);
-  const file = new File([content], 'bigFile.txt', { type: 'text/plain' });
-  return file;
-}
-const TestComponent = (filePickerProps?: UseFilePickerConfig) => {
-  const [openFileSelector, { plainFiles, loading, errors }] = useFilePicker({
-    accept: '*',
-    readAs: 'DataURL',
-    initializeWithCustomParameters: input => input.setAttribute('data-testid', 'tested'),
-    ...filePickerProps,
-  });
-  return (
-    <div>
-      <button
-        onClick={() => {
-          openFileSelector();
-        }}
-      >
-        Click me
-      </button>
-      <h2>Files length : {plainFiles.length}</h2>
-      {loading && <h1>Loading...</h1>}
-      {errors.length ? (
-        <div>
-          errors:
-          <br />
-          {Object.entries(errors[0])
-            .filter(([, value]) => value === true)
-            .map(([key]) => key)
-            .map(key => (
-              <div key={key} style={{ color: 'red' }}>
-                {key}
-              </div>
-            ))}
-        </div>
-      ) : null}
-    </div>
-  );
-};
+import { waitFor } from '@testing-library/react';
+import { createFileOfSize, invokeUseFilePicker } from './testUtils';
 
 describe('FileRestrictions', () => {
   it('should check maximum file size', async () => {
-    render(<TestComponent maxFileSize={2}></TestComponent>);
+    const { input, result } = invokeUseFilePicker({ maxFileSize: 2 });
 
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
+    const bigFile = createFileOfSize(10240 * 1024);
+    await userEvent.upload(input.current!, bigFile);
 
-    let input = screen.getByTestId('tested');
+    await waitFor(() => result.current[1].loading === false);
 
-    if (!isInputElement(input)) throw new Error('Input not found');
-
-    const bigFile = createBigFile(10240 * 1024);
-    await userEvent.upload(input, bigFile);
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-    expect(screen.getByText('fileSizeToolarge')).toBeInTheDocument();
+    expect(result.current[1].errors[0].fileSizeToolarge).toBe(true);
   });
+
   it('should check minimum file size', async () => {
-    render(<TestComponent minFileSize={1}></TestComponent>);
+    const { input, result } = invokeUseFilePicker({ minFileSize: 1 });
 
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
+    const bigFile = createFileOfSize(0);
+    await userEvent.upload(input.current!, bigFile);
 
-    let input = screen.getByTestId('tested');
+    await waitFor(() => result.current[1].loading === false);
 
-    if (!isInputElement(input)) throw new Error('Input not found');
-
-    const bigFile = createBigFile(0);
-    await userEvent.upload(input, bigFile);
-
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-    expect(screen.getByText('fileSizeTooSmall')).toBeInTheDocument();
+    expect(result.current[1].errors[0].fileSizeTooSmall).toBe(true);
   });
+
   it('should not allow to put more files than specified', async () => {
-    render(<TestComponent limitFilesConfig={{ max: 3 }}></TestComponent>);
-
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
-
-    let input = screen.getByTestId('tested');
-
-    if (!isInputElement(input)) throw new Error('Input not found');
+    const { input, result } = invokeUseFilePicker({ limitFilesConfig: { max: 3 } });
 
     const files = [new File([''], 'file1'), new File([''], 'file2'), new File([''], 'file3'), new File([''], 'file4')];
-    await userEvent.upload(input, files);
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-    expect(screen.getByText('maxLimitExceeded')).toBeInTheDocument();
+    await userEvent.upload(input.current!, files);
+
+    await waitFor(() => result.current[1].loading === false);
+
+    expect(result.current[1].errors[0].maxLimitExceeded).toBe(true);
   });
+
   it('should allow to put more files than specified', async () => {
-    render(<TestComponent limitFilesConfig={{ min: 3 }}></TestComponent>);
-
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
-
-    let input = screen.getByTestId('tested');
-
-    if (!isInputElement(input)) throw new Error('Input not found');
+    const { input, result } = invokeUseFilePicker({ limitFilesConfig: { min: 3 } });
 
     const files = [new File([''], 'file1'), new File([''], 'file2'), new File([''], 'file3'), new File([''], 'file4')];
-    await userEvent.upload(input, files);
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-    await waitForElementToBeRemoved(() => screen.queryByText(/loading.../i));
-    expect(screen.getByText(/Files length : 4/i)).toBeInTheDocument();
+    await userEvent.upload(input.current!, files);
+
+    await waitFor(() => result.current[1].loading === false);
+
+    expect(result.current[1].errors.length).toBe(0);
+    expect(result.current[1].plainFiles.length).toBe(4);
   });
+
   it('should not allow to put less files than specified', async () => {
-    render(<TestComponent limitFilesConfig={{ min: 3 }}></TestComponent>);
-
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
-
-    let input = screen.getByTestId('tested');
-
-    if (!isInputElement(input)) throw new Error('Input not found');
+    const { input, result } = invokeUseFilePicker({ limitFilesConfig: { min: 3 } });
 
     const files = [new File([''], 'file1'), new File([''], 'file2')];
-    await userEvent.upload(input, files);
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-    expect(screen.getByText('minLimitNotReached')).toBeInTheDocument();
+    await userEvent.upload(input.current!, files);
+
+    await waitFor(() => result.current[1].loading === false);
+
+    expect(result.current[1].errors[0].minLimitNotReached).toBe(true);
   });
+
   it('should allow to put less files than specified', async () => {
-    render(<TestComponent limitFilesConfig={{ max: 3 }}></TestComponent>);
-
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
-
-    let input = screen.getByTestId('tested');
-
-    if (!isInputElement(input)) throw new Error('Input not found');
+    const { input, result } = invokeUseFilePicker({ limitFilesConfig: { max: 3 } });
 
     const files = [new File([''], 'file1'), new File([''], 'file2')];
-    await userEvent.upload(input, files);
+    await userEvent.upload(input.current!, files);
 
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
+    await waitFor(() => result.current[1].loading === false);
 
-    expect(screen.getByText(/Files length : 2/i)).toBeInTheDocument();
-  });
-  it('should display loading indicator when loading and remove it when done loading', async () => {
-    render(<TestComponent></TestComponent>);
-
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
-
-    let input = screen.getByTestId('tested');
-
-    if (!isInputElement(input)) throw new Error('Input not found');
-
-    const files = [new File([''], 'file1'), new File([''], 'file2')];
-    await userEvent.upload(input, files);
-
-    expect(screen.queryByText(/loading.../i)).toBeInTheDocument();
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-
-    await waitForElementToBeRemoved(() => screen.queryByText(/loading.../i));
-    expect(screen.queryByText(/loading.../i)).not.toBeInTheDocument();
+    expect(result.current[1].errors.length).toBe(0);
+    expect(result.current[1].plainFiles.length).toBe(2);
   });
 });

--- a/test/FilePicker.test.tsx
+++ b/test/FilePicker.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { DefaultPicker } from '../stories/FilePicker.stories';
-import { useFilePicker } from '../src/index';
+import { invokeUseFilePicker } from './testUtils';
 
 describe('DefaultPicker', () => {
   it('renders without crashing', async () => {
@@ -13,68 +13,22 @@ describe('DefaultPicker', () => {
   });
 });
 
-const isInputElement = (el: HTMLElement): el is HTMLInputElement => el instanceof HTMLInputElement;
-
-const SomeRandomComponent = () => {
-  const [openFileSelector, { plainFiles, loading, errors }] = useFilePicker({
-    accept: '*',
-    multiple: true,
-    initializeWithCustomParameters: input => input.setAttribute('data-testid', 'tested'),
-  });
-  return (
-    <div>
-      <button
-        onClick={() => {
-          openFileSelector();
-        }}
-      >
-        Click me
-      </button>
-      <h2>Files length : {plainFiles.length}</h2>
-      {loading && <h1>Loading...</h1>}
-      {errors.length ? (
-        <div>
-          errors:
-          <br />
-          {Object.entries(errors[0])
-            .filter(([, value]) => value === true)
-            .map(([key]) => key)
-            .map(key => (
-              <div key={key} style={{ color: 'red' }}>
-                {key}
-              </div>
-            ))}
-        </div>
-      ) : null}
-    </div>
-  );
-};
-
 describe('DefaultPicker', () => {
   it('should upload files correctly', async () => {
     const user = userEvent.setup();
-    render(<SomeRandomComponent></SomeRandomComponent>);
-    // get the upload button
-    let uploader = screen.getByRole('button', {});
-    await user.click(uploader);
-
-    let input = screen.getByTestId('tested');
-
-    if (!isInputElement(input)) throw new Error('Input not found');
+    const { input, result } = invokeUseFilePicker({});
 
     const files = [
       new File(['hello'], 'hello.png', { type: 'image/png' }),
       new File(['there'], 'there.png', { type: 'image/png' }),
     ];
-    await user.upload(input, files);
+    await user.upload(input.current!, files);
 
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-    await waitForElementToBeRemoved(() => screen.queryByText(/loading.../i));
-    await screen.findByText(/files length : 2/i);
+    await waitFor(() => result.current[1].loading === false);
 
-    expect(input.files).toHaveLength(2);
-    expect(input.files).toBeTruthy();
-    expect(input.files?.[0]).toStrictEqual(files[0]);
-    expect(input.files?.[1]).toStrictEqual(files[1]);
+    expect(result.current[1].plainFiles.length).toBe(2);
+    expect(input.current!.files).toHaveLength(2);
+    expect(input.current!.files?.[0]).toStrictEqual(files[0]);
+    expect(input.current!.files?.[1]).toStrictEqual(files[1]);
   });
 });

--- a/test/ImageSize.test.tsx
+++ b/test/ImageSize.test.tsx
@@ -1,143 +1,68 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
-import { useFilePicker, UseFilePickerConfig } from '../src/index';
-
-const isInputElement = (el: HTMLElement): el is HTMLInputElement => el instanceof HTMLInputElement;
-function createBigFile(sizeInBytes: number) {
-  const content = new ArrayBuffer(sizeInBytes);
-  const file = new File([content], 'bigFile.txt', { type: 'text/plain' });
-  return file;
-}
-const TestComponent = (filePickerProps?: UseFilePickerConfig) => {
-  const [openFileSelector, { plainFiles, loading, errors }] = useFilePicker({
-    accept: '*',
-    readAs: 'DataURL',
-    initializeWithCustomParameters: input => input.setAttribute('data-testid', 'tested'),
-    ...filePickerProps,
-  });
-  return (
-    <div>
-      <button
-        onClick={() => {
-          openFileSelector();
-        }}
-      >
-        Click me
-      </button>
-      <h2>Files length : {plainFiles.length}</h2>
-      {loading && <h1>Loading...</h1>}
-      {errors.length ? (
-        <div>
-          errors:
-          <br />
-          {Object.entries(errors[0])
-            .filter(([, value]) => value === true)
-            .map(([key]) => key)
-            .map(key => (
-              <div key={key} style={{ color: 'red' }}>
-                {key}
-              </div>
-            ))}
-        </div>
-      ) : null}
-    </div>
-  );
-};
+import { waitFor } from '@testing-library/react';
+import { createFileOfSize, invokeUseFilePicker } from './testUtils';
 
 describe('FileRestrictions', () => {
   it('should check maximum file size', async () => {
-    render(<TestComponent maxFileSize={2}></TestComponent>);
+    const { input, result } = invokeUseFilePicker({ maxFileSize: 2 });
 
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
+    const bigFile = createFileOfSize(10240 * 1024);
+    await userEvent.upload(input.current!, bigFile);
 
-    let input = screen.getByTestId('tested');
+    await waitFor(() => result.current[1].loading === false);
 
-    if (!isInputElement(input)) throw new Error('Input not found');
-
-    const bigFile = createBigFile(10240 * 1024);
-    await userEvent.upload(input, bigFile);
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-    expect(screen.getByText('fileSizeToolarge')).toBeInTheDocument();
+    expect(result.current[1].errors[0].fileSizeToolarge).toBe(true);
   });
+
   it('should check minimum file size', async () => {
-    render(<TestComponent minFileSize={1}></TestComponent>);
+    const { input, result } = invokeUseFilePicker({ minFileSize: 1 });
 
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
+    const bigFile = createFileOfSize(0);
+    await userEvent.upload(input.current!, bigFile);
 
-    let input = screen.getByTestId('tested');
-
-    if (!isInputElement(input)) throw new Error('Input not found');
-
-    const bigFile = createBigFile(0);
-    await userEvent.upload(input, bigFile);
-
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-    expect(screen.getByText('fileSizeTooSmall')).toBeInTheDocument();
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].errors[0].fileSizeTooSmall).toBe(true);
   });
-  it('should not allow to put more files than specified', async () => {
-    render(<TestComponent limitFilesConfig={{ max: 3 }}></TestComponent>);
 
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
-
-    let input = screen.getByTestId('tested');
-
-    if (!isInputElement(input)) throw new Error('Input not found');
+  it('should not allow to put more files than maximum specified', async () => {
+    const { input, result } = invokeUseFilePicker({ limitFilesConfig: { max: 3 } });
 
     const files = [new File([''], 'file1'), new File([''], 'file2'), new File([''], 'file3'), new File([''], 'file4')];
-    await userEvent.upload(input, files);
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-    expect(screen.getByText('maxLimitExceeded')).toBeInTheDocument();
+    await userEvent.upload(input.current!, files);
+
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].errors[0].maxLimitExceeded).toBe(true);
   });
-  it('should allow to put more files than specified', async () => {
-    render(<TestComponent limitFilesConfig={{ min: 3 }}></TestComponent>);
 
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
+  it('should allow to put less files than maximum specified', async () => {
+    const { input, result } = invokeUseFilePicker({ limitFilesConfig: { max: 3 } });
 
-    let input = screen.getByTestId('tested');
+    const files = [new File([''], 'file1'), new File([''], 'file2')];
+    await userEvent.upload(input.current!, files);
 
-    if (!isInputElement(input)) throw new Error('Input not found');
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].errors.length).toBe(0);
+    expect(result.current[1].plainFiles.length).toBe(2);
+  });
+
+  it('should allow to put more files than minimum specified', async () => {
+    const { input, result } = invokeUseFilePicker({ limitFilesConfig: { min: 3 } });
 
     const files = [new File([''], 'file1'), new File([''], 'file2'), new File([''], 'file3'), new File([''], 'file4')];
-    await userEvent.upload(input, files);
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-    await waitForElementToBeRemoved(() => screen.queryByText(/loading.../i));
-    expect(screen.getByText(/Files length : 4/i)).toBeInTheDocument();
+    await userEvent.upload(input.current!, files);
+
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].plainFiles.length).toBe(4);
   });
-  it('should not allow to put less files than specified', async () => {
-    render(<TestComponent limitFilesConfig={{ min: 3 }}></TestComponent>);
 
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
-
-    let input = screen.getByTestId('tested');
-
-    if (!isInputElement(input)) throw new Error('Input not found');
+  it('should not allow to put less files than minimum specified', async () => {
+    const { input, result } = invokeUseFilePicker({ limitFilesConfig: { min: 3 } });
 
     const files = [new File([''], 'file1'), new File([''], 'file2')];
-    await userEvent.upload(input, files);
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-    expect(screen.getByText('minLimitNotReached')).toBeInTheDocument();
-  });
-  it('should allow to put less files than specified', async () => {
-    render(<TestComponent limitFilesConfig={{ max: 3 }}></TestComponent>);
+    await userEvent.upload(input.current!, files);
 
-    let uploader = screen.getByRole('button', {});
-    await userEvent.click(uploader);
-
-    let input = screen.getByTestId('tested');
-
-    if (!isInputElement(input)) throw new Error('Input not found');
-
-    const files = [new File([''], 'file1'), new File([''], 'file2')];
-    await userEvent.upload(input, files);
-    expect(screen.queryByTestId('tested')).not.toBeInTheDocument();
-
-    expect(screen.getByText(/Files length : 2/i)).toBeInTheDocument();
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].errors[0].minLimitNotReached).toBe(true);
   });
 });

--- a/test/ImperativeFilePicker.test.tsx
+++ b/test/ImperativeFilePicker.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { render, act, waitFor } from '@testing-library/react';
+import { ImperativePicker } from '../stories/ImperativeFilePicker.stories';
+import { invokeUseImperativeFilePicker, isInputElement } from './testUtils';
+
+describe('DefaultPicker', () => {
+  it('renders without crashing', async () => {
+    const { findByRole } = render(<ImperativePicker />);
+    const button = await findByRole('button');
+    expect(button).toBeInTheDocument();
+  });
+});
+
+describe('ImperativeFilePicker', () => {
+  it('should keep selected files in state after new selection', async () => {
+    const user = userEvent.setup();
+    const { input, result } = invokeUseImperativeFilePicker({});
+
+    const files = [
+      new File(['hello'], 'hello.png', { type: 'image/png' }),
+      new File(['there'], 'there.png', { type: 'image/png' }),
+    ];
+    await user.upload(input.current, files);
+
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].plainFiles.length).toBe(2);
+
+    act(() => {
+      result.current[0]();
+    });
+
+    if (!isInputElement(input.current!)) throw new Error('Input not found');
+
+    const newFile = [new File(['new'], 'new.png', { type: 'image/png' })];
+    await user.upload(input.current, newFile);
+
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].plainFiles.length).toBe(3);
+  });
+
+  it('should allow to remove files by index', async () => {
+    const user = userEvent.setup();
+    const { input, result } = invokeUseImperativeFilePicker({});
+
+    const files = [
+      new File(['hello'], 'hello.png', { type: 'image/png' }),
+      new File(['there'], 'there.png', { type: 'image/png' }),
+      new File(['new'], 'new.png', { type: 'image/png' }),
+    ];
+    await user.upload(input.current, files);
+
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].plainFiles.length).toBe(3);
+
+    act(() => {
+      result.current[1].removeFileByIndex(1); // remove the second file
+    });
+
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].plainFiles.length).toBe(2);
+    expect(result.current[1].plainFiles[0].name).toBe('hello.png');
+    expect(result.current[1].plainFiles[1].name).toBe('new.png');
+  });
+
+  it('should allow to remove files by reference', async () => {
+    const user = userEvent.setup();
+    const { input, result } = invokeUseImperativeFilePicker({});
+
+    const files = [
+      new File(['hello'], 'hello.png', { type: 'image/png' }),
+      new File(['there'], 'there.png', { type: 'image/png' }),
+      new File(['new'], 'new.png', { type: 'image/png' }),
+    ];
+    await user.upload(input.current, files);
+
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].plainFiles.length).toBe(3);
+
+    act(() => {
+      const fileToBeRemoved = result.current[1].plainFiles[1]; // remove the second file
+      result.current[1].removeFileByReference(fileToBeRemoved); // remove the second file
+    });
+
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].plainFiles.length).toBe(2);
+    expect(result.current[1].plainFiles[0].name).toBe('hello.png');
+    expect(result.current[1].plainFiles[1].name).toBe('new.png');
+  });
+
+  it('should allow to clear the selection', async () => {
+    const user = userEvent.setup();
+    const { input, result } = invokeUseImperativeFilePicker({});
+
+    const files = [
+      new File(['hello'], 'hello.png', { type: 'image/png' }),
+      new File(['there'], 'there.png', { type: 'image/png' }),
+      new File(['new'], 'new.png', { type: 'image/png' }),
+    ];
+    await user.upload(input.current, files);
+
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].plainFiles.length).toBe(3);
+
+    act(() => {
+      result.current[1].clear();
+    });
+
+    await waitFor(() => result.current[1].loading === false);
+    expect(result.current[1].plainFiles.length).toBe(0);
+  });
+});

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react';
+import useFilePicker from '../src/useFilePicker';
+import { ImperativeFilePickerReturnTypes, UseFilePickerConfig, useImperativeFilePicker } from '../src';
+
+export const isInputElement = (el: HTMLElement): el is HTMLInputElement => el instanceof HTMLInputElement;
+
+export function createFileOfSize(sizeInBytes: number) {
+  const content = new ArrayBuffer(sizeInBytes);
+  const file = new File([content], 'bigFile.txt', { type: 'text/plain' });
+  return file;
+}
+
+type UseFilePickerHook = typeof useFilePicker | typeof useImperativeFilePicker;
+
+const invokeFilePicker = (props: UseFilePickerConfig, usePickerHook: UseFilePickerHook) => {
+  let input: { current: HTMLInputElement | null } = { current: null };
+
+  const { result } = renderHook(() =>
+    usePickerHook({
+      ...props,
+      initializeWithCustomParameters(inputElement) {
+        input.current = inputElement;
+      },
+    })
+  );
+
+  act(() => {
+    result.current[0]();
+  });
+
+  if (!isInputElement(input.current!)) throw new Error('Input not found');
+
+  return {
+    result,
+    input,
+  };
+};
+
+export const invokeUseFilePicker = (props: UseFilePickerConfig) => invokeFilePicker(props, useFilePicker);
+
+export const invokeUseImperativeFilePicker = (props: UseFilePickerConfig) =>
+  invokeFilePicker(props, useImperativeFilePicker) as {
+    result: {
+      current: ImperativeFilePickerReturnTypes;
+    };
+    input: { current: HTMLInputElement };
+  };


### PR DESCRIPTION
This pull request introduces a fix for issue #67, where users reported an error when trying to delete files from the `filesContent` array in the useFilePicker component. The issue arises when the user tries to reopen the uploader after removing files, causing the application to break. This PR addresses the issue by enhancing the useFilePicker component to support file deletion and multiple upload attempts (requested in #51)

The new functionality is implemented as a separate hook called `useImperativeFilePicker` and allows for removing files and keeping the previous selections.
