### PR TITLE
Fix useFilePicker return type for readAs ArrayBuffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-file-picker",
   "description": "Simple react hook to open browser file selector.",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "author": "Milosz Jankiewicz",
   "homepage": "https://github.com/Jaaneek/useFilePicker",

--- a/src/validators/imageDimensionsValidator/index.ts
+++ b/src/validators/imageDimensionsValidator/index.ts
@@ -1,5 +1,5 @@
 import { FileWithPath } from 'file-selector';
-import { ImageDimensionError, ImageDims, UseFilePickerConfig } from '../../interfaces';
+import { ImageDimensionError, ImageDimensionRestrictionsConfig, UseFilePickerConfig } from '../../interfaces';
 import { Validator } from '../validatorInterface';
 
 export default class ImageDimensionsValidator implements Validator {
@@ -17,7 +17,7 @@ export default class ImageDimensionsValidator implements Validator {
 
 const isImage = (fileType: string) => fileType.startsWith('image');
 
-const checkImageDimensions = (imgDataURL: string, imageSizeRestrictions: ImageDims) =>
+const checkImageDimensions = (imgDataURL: string, imageSizeRestrictions: ImageDimensionRestrictionsConfig) =>
   new Promise<void>((resolve, reject) => {
     const img = new Image();
     img.onload = function () {

--- a/stories/FilePicker.stories.tsx
+++ b/stories/FilePicker.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from '@storybook/react';
 import { useFilePicker, Validator } from '../src';
 import { FileContent, ReadType, UseFilePickerConfig } from '../src/interfaces';
 
-const renderDependingOnReaderType = (file: FileContent, readAs: ReadType) => {
+const renderDependingOnReaderType = (file: FileContent<string>, readAs: ReadType) => {
   switch (readAs) {
     case 'DataURL':
       return (

--- a/stories/ImperativeFilePicker.stories.tsx
+++ b/stories/ImperativeFilePicker.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from '@storybook/react';
 import { useImperativeFilePicker, Validator } from '../src';
 import { FileContent, ReadType, UseFilePickerConfig } from '../src/interfaces';
 
-const renderDependingOnReaderType = (file: FileContent, readAs: ReadType) => {
+const renderDependingOnReaderType = (file: FileContent<string>, readAs: ReadType) => {
   switch (readAs) {
     case 'DataURL':
       return (

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,6 +1,11 @@
 import { act, renderHook } from '@testing-library/react';
 import useFilePicker from '../src/useFilePicker';
-import { ImperativeFilePickerReturnTypes, UseFilePickerConfig, useImperativeFilePicker } from '../src';
+import {
+  ExtractContentTypeFromConfig,
+  ImperativeFilePickerReturnTypes,
+  UseFilePickerConfig,
+  useImperativeFilePicker,
+} from '../src';
 
 export const isInputElement = (el: HTMLElement): el is HTMLInputElement => el instanceof HTMLInputElement;
 
@@ -38,10 +43,10 @@ const invokeFilePicker = (props: UseFilePickerConfig, usePickerHook: UseFilePick
 
 export const invokeUseFilePicker = (props: UseFilePickerConfig) => invokeFilePicker(props, useFilePicker);
 
-export const invokeUseImperativeFilePicker = (props: UseFilePickerConfig) =>
+export const invokeUseImperativeFilePicker = <T extends UseFilePickerConfig>(props: T) =>
   invokeFilePicker(props, useImperativeFilePicker) as {
     result: {
-      current: ImperativeFilePickerReturnTypes;
+      current: ImperativeFilePickerReturnTypes<ExtractContentTypeFromConfig<T>>;
     };
     input: { current: HTMLInputElement };
   };


### PR DESCRIPTION
Fix for #70 
In addition, I've changed the config type to discriminated union, so the end user cannot pass `readAs` prop when `readFilesContent` is set to false.
