### PR TITLE
fix: spelling mistake onFilesSuccessfullySelected

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ export default function App() {
       // this callback is called when there were validation errors
       console.log('onFilesRejected', errors);
     },
-    onFilesSuccessfulySelected: ({ plainFiles, filesContent }) => {
+    onFilesSuccessfullySelected: ({ plainFiles, filesContent }) => {
       // this callback is called when there were no validation errors
-      console.log('onFilesSuccessfulySelected', plainFiles, filesContent);
+      console.log('onFilesSuccessfullySelected', plainFiles, filesContent);
     },
   });
 
@@ -239,9 +239,9 @@ const Imperative = () => {
       // this callback is called when there were validation errors
       console.log('onFilesRejected', errors);
     },
-    onFilesSuccessfulySelected: ({ plainFiles, filesContent }) => {
+    onFilesSuccessfullySelected: ({ plainFiles, filesContent }) => {
       // this callback is called when there were no validation errors
-      console.log('onFilesSuccessfulySelected', plainFiles, filesContent);
+      console.log('onFilesSuccessfullySelected', plainFiles, filesContent);
     },
   });
 
@@ -312,7 +312,7 @@ const Imperative = () => {
 | validators                     | Add custom [validation](#custom-validation) logic                                                                                                                                                                              | []            | [MyValidator, MySecondValidator]                  |
 | initializeWithCustomParameters | allows for customization of the input element that is created by the file picker. It accepts a function that takes in the input element as a parameter and can be used to set any desired attributes or styles on the element. | n/a           | (input) => input.setAttribute("disabled", "")     |
 | onFilesSelected                | A callback function that is called when files are successfully selected. The function is passed an array of objects with information about each successfully selected file                                                     | n/a           | (data) => console.log(data)                       |
-| onFilesSuccessfulySelected     | A callback function that is called when files are successfully selected. The function is passed an array of objects with information about each successfully selected file                                                     | n/a           | (data) => console.log(data)                       |
+| onFilesSuccessfullySelected     | A callback function that is called when files are successfully selected. The function is passed an array of objects with information about each successfully selected file                                                     | n/a           | (data) => console.log(data)                       |
 | onFilesRejected                | A callback function that is called when files are rejected due to validation errors or other issues. The function is passed an array of objects with information about each rejected file                                      | n/a           | (data) => console.log(data)                       |
 
 ### Returns
@@ -384,7 +384,7 @@ UseFilePickerConfig extends Options {
   imageSizeRestrictions?: ImageDims;
   validators?: Validator[];
   onFilesSelected?: (data: SelectedFilesOrErrors) => void;
-  onFilesSuccessfulySelected?: (data: SelectedFiles) => void;
+  onFilesSuccessfullySelected?: (data: SelectedFiles) => void;
   onFilesRejected?: (data: FileErrors) => void;
   initializeWithCustomParameters?: (inputElement: HTMLInputElement) => void;
 }

--- a/example/imperative.tsx
+++ b/example/imperative.tsx
@@ -18,9 +18,9 @@ const Imperative = () => {
       // this callback is called when there were validation errors
       console.log('onFilesRejected', errors);
     },
-    onFilesSuccessfulySelected: ({ plainFiles, filesContent }) => {
+    onFilesSuccessfullySelected: ({ plainFiles, filesContent }) => {
       // this callback is called when there were no validation errors
-      console.log('onFilesSuccessfulySelected', plainFiles, filesContent);
+      console.log('onFilesSuccessfullySelected', plainFiles, filesContent);
     },
   });
 

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -54,9 +54,9 @@ const App = () => {
       // this callback is called when there were validation errors
       console.log('onFilesRejected', errors);
     },
-    onFilesSuccessfulySelected: ({ plainFiles, filesContent }) => {
+    onFilesSuccessfullySelected: ({ plainFiles, filesContent }) => {
       // this callback is called when there were no validation errors
-      console.log('onFilesSuccessfulySelected', plainFiles, filesContent);
+      console.log('onFilesSuccessfullySelected', plainFiles, filesContent);
     },
   });
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -30,7 +30,7 @@ export interface UseFilePickerConfig extends Options {
   imageSizeRestrictions?: ImageDims;
   validators?: Validator[];
   onFilesSelected?: (data: SelectedFilesOrErrors) => void;
-  onFilesSuccessfulySelected?: (data: SelectedFiles) => void;
+  onFilesSuccessfullySelected?: (data: SelectedFiles) => void;
   onFilesRejected?: (data: FileErrors) => void;
   initializeWithCustomParameters?: (inputElement: HTMLInputElement) => void;
 }

--- a/src/useFilePicker.tsx
+++ b/src/useFilePicker.tsx
@@ -17,7 +17,7 @@ function useFilePicker(props: UseFilePickerConfig): FilePickerReturnTypes {
     readFilesContent = true,
     validators = [],
     onFilesSelected,
-    onFilesSuccessfulySelected,
+    onFilesSuccessfullySelected,
     onFilesRejected,
     initializeWithCustomParameters,
   } = props;
@@ -129,7 +129,7 @@ function useFilePicker(props: UseFilePickerConfig): FilePickerReturnTypes {
         setFilesContent(filesContent);
         setPlainFiles(plainFileObjects);
         setFileErrors([]);
-        onFilesSuccessfulySelected?.({ filesContent, plainFiles: plainFileObjects });
+        onFilesSuccessfullySelected?.({ filesContent, plainFiles: plainFileObjects });
         onFilesSelected?.({
           plainFiles: plainFileObjects,
           filesContent,

--- a/src/useImperativeFilePicker.tsx
+++ b/src/useImperativeFilePicker.tsx
@@ -7,7 +7,7 @@ import persistentFileLimitValidator from './validators/persistentFilesLimitValid
  * A version of useFilePicker hook that keeps selected files between selections. On top of that it allows to remove files from the selection.
  */
 function useImperativeFilePicker(props: UseFilePickerConfig): ImperativeFilePickerReturnTypes {
-  const { readFilesContent, onFilesSelected, onFilesSuccessfulySelected } = props;
+  const { readFilesContent, onFilesSelected, onFilesSuccessfullySelected } = props;
 
   const [allPlainFiles, setAllPlainFiles] = useState<File[]>([]);
   const [allFilesContent, setAllFilesContent] = useState<FileContent[]>([]);
@@ -27,13 +27,13 @@ function useImperativeFilePicker(props: UseFilePickerConfig): ImperativeFilePick
         filesContent: [...allFilesContent, ...(data.filesContent || [])],
       });
     },
-    onFilesSuccessfulySelected: data => {
+    onFilesSuccessfullySelected: data => {
       setAllPlainFiles(previousPlainFiles => previousPlainFiles.concat(data.plainFiles));
       setAllFilesContent(previousFilesContent => previousFilesContent.concat(data.filesContent));
 
-      if (!onFilesSuccessfulySelected) return;
+      if (!onFilesSuccessfullySelected) return;
       // override the files property to return all files that were selected previously and in the current batch
-      onFilesSuccessfulySelected({
+      onFilesSuccessfullySelected({
         plainFiles: [...allPlainFiles, ...(data.plainFiles || [])],
         filesContent: [...allFilesContent, ...(data.filesContent || [])],
       });

--- a/stories/FilePicker.stories.tsx
+++ b/stories/FilePicker.stories.tsx
@@ -106,7 +106,7 @@ const meta: Meta = {
     onFilesRejected: {
       description: 'Callback that is invoked when selected files are rejected due to an error',
     },
-    onFilesSuccessfulySelected: {
+    onFilesSuccessfullySelected: {
       description: 'Callback that is invoked when selected files are successfully selected',
     },
     onFilesSelected: {
@@ -225,12 +225,12 @@ export const onFilesSelected = Template.bind(
     },
   }
 );
-export const onFilesSuccessfulySelected = Template.bind(
+export const onFilesSuccessfullySelected = Template.bind(
   {},
   {
     storyTitle:
-      'Triggers when user selects files without errors. The onFilesSuccessfulySelected callback runs with sucessfuly selected files',
-    onFilesSuccessfulySelected: (data: any) => alert(`successfuly selected ${data.plainFiles.length} files`),
+      'Triggers when user selects files without errors. The onFilesSuccessfullySelected callback runs with sucessfuly selected files',
+    onFilesSuccessfullySelected: (data: any) => alert(`successfully selected ${data.plainFiles.length} files`),
   }
 );
 

--- a/stories/ImperativeFilePicker.stories.tsx
+++ b/stories/ImperativeFilePicker.stories.tsx
@@ -106,7 +106,7 @@ const meta: Meta = {
     onFilesRejected: {
       description: 'Callback that is invoked when selected files are rejected due to an error',
     },
-    onFilesSuccessfulySelected: {
+    onFilesSuccessfullySelected: {
       description: 'Callback that is invoked when selected files are successfully selected',
     },
     onFilesSelected: {
@@ -231,12 +231,12 @@ export const ImperativeOnFilesSelected = Template.bind(
     },
   }
 );
-export const ImperativeOnFilesSuccessfulySelected = Template.bind(
+export const ImperativeOnFilesSuccessfullySelected = Template.bind(
   {},
   {
     storyTitle:
-      'Triggers when user selects files without errors. The onFilesSuccessfulySelected callback runs with sucessfuly selected files',
-    onFilesSuccessfulySelected: (data: any) => alert(`successfuly selected ${data.plainFiles.length} files`),
+      'Triggers when user selects files without errors. The onFilesSuccessfullySelected callback runs with sucessfuly selected files',
+    onFilesSuccessfullySelected: (data: any) => alert(`successfully selected ${data.plainFiles.length} files`),
   }
 );
 


### PR DESCRIPTION
Hello 👋
First of all thank you for the great work with this package, I have been using it for a while now.
I am currently working on a project where spell checking is part of the automated tests. Therefore I am not able to make use of the `onFilesSuccessfulySelected` callback function. Correctly spelled would it have to be `onFilesSuccessfullySelected` with two `L`'s.
Actually this can be considered a breaking change for the consumer side, so maybe a new npm major version would be needed.