### PR TITLE
Add onFileRemoved callback to useImperativeFilePicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,25 @@ export default function App() {
       // this callback is called when there were no validation errors
       console.log('onFilesSuccessfullySelected', plainFiles, filesContent);
     },
+    onClear: () => {
+      // this callback is called when the selection is cleared
+      console.log('onClear');
+    },
+  });
+}
+```
+
+`useImperativePicker` hook also accepts the callbacks listed above. Additionally, it accepts the `onFileRemoved` callback, which is called when a file is removed from the list of selected files.
+
+```ts
+import { useImperativeFilePicker } from 'use-file-picker';
+
+export default function App() {
+  const { openFilePicker, filesContent, loading, errors, plainFiles, clear } = useImperativeFilePicker({
+    onFileRemoved: (removedFile, removedIndex) => {
+      // this callback is called when a file is removed from the list of selected files
+      console.log('onFileRemoved', removedFile, removedIndex);
+    },
   });
 }
 ```
@@ -405,8 +424,9 @@ Since version 2.0, validators also have optional callback handlers that will be 
    * This method is called when file is removed from the list of selected files.
    * Invoked only by the useImperativeFilePicker hook
    * @param _removedIndex index of removed file
+   * @param _removedFile removed file
    */
-  onFileRemoved(_removedIndex: number): Promise<void> | void {}
+  onFileRemoved(_removedIndex: number, _removedFile: File): Promise<void> | void {}
 ```
 
 #### Example validator

--- a/README.md
+++ b/README.md
@@ -423,10 +423,10 @@ Since version 2.0, validators also have optional callback handlers that will be 
   /**
    * This method is called when file is removed from the list of selected files.
    * Invoked only by the useImperativeFilePicker hook
-   * @param _removedIndex index of removed file
    * @param _removedFile removed file
+   * @param _removedIndex index of removed file
    */
-  onFileRemoved(_removedIndex: number, _removedFile: File): Promise<void> | void {}
+  onFileRemoved(_removedFile: File, _removedIndex: number): Promise<void> | void {}
 ```
 
 #### Example validator

--- a/example/imperative.tsx
+++ b/example/imperative.tsx
@@ -25,6 +25,10 @@ const Imperative = () => {
         // this callback is called when there were no validation errors
         console.log('onFilesSuccessfullySelected', plainFiles, filesContent);
       },
+      onFileRemoved(file, removedIndex) {
+        // this callback is called when file is removed
+        console.log('onFileRemoved', file, removedIndex);
+      },
     });
 
   if (loading) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-file-picker",
   "description": "Simple react hook to open browser file selector.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "Milosz Jankiewicz",
   "homepage": "https://github.com/Jaaneek/useFilePicker",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -118,6 +118,10 @@ export type ExtractContentTypeFromConfig<Config> = Config extends { readAs: 'Arr
 export type UseFilePickerConfig<CustomErrors = unknown> = UseFilePickerConfigCommon &
   ReadFileContentConfig<CustomErrors>;
 
+export type useImperativeFilePickerConfig<CustomErrors = unknown> = UseFilePickerConfig<CustomErrors> & {
+  onFileRemoved?: (file: FileWithPath, removedIndex: number) => void | Promise<void>;
+};
+
 export interface FileContent<ContentType> extends Blob {
   lastModified: number;
   name: string;

--- a/src/validators/persistentFileAmountLimitValidator/index.ts
+++ b/src/validators/persistentFileAmountLimitValidator/index.ts
@@ -12,7 +12,7 @@ class PersistentFileAmountLimitValidator extends Validator {
     this.previousPlainFiles = [];
   }
 
-  onFileRemoved(removedIndex: number): void {
+  onFileRemoved(_removedFile: File, removedIndex: number): void {
     this.previousPlainFiles.splice(removedIndex, 1);
   }
 

--- a/src/validators/validatorBase.ts
+++ b/src/validators/validatorBase.ts
@@ -49,7 +49,8 @@ export abstract class Validator<
   /**
    * This method is called when file is removed from the list of selected files.
    * Invoked only by the useImperativeFilePicker hook
+   * @param _removedFile removed file
    * @param _removedIndex index of removed file
    */
-  onFileRemoved(_removedIndex: number): Promise<void> | void {}
+  onFileRemoved(_removedFile: File, _removedIndex: number): Promise<void> | void {}
 }


### PR DESCRIPTION
Fix for #79. Adds a `onFileRemoved` callback to `useImperativeFilePicker` which now gets the removed file and its index.